### PR TITLE
chore: dev -> main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,10 @@ jobs:
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
-          flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
+          flyctl deploy --remote-only \
+          --build-arg COMMIT_SHA=${{ github.sha }} \
+          --build-arg SENTRY_ORG=${{ secrets.SENTRY_ORG }} \
+          --build-arg SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }} \
           --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,11 +50,10 @@ jobs:
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
-          flyctl deploy --remote-only \
-          --build-arg COMMIT_SHA=${{ github.sha }} \
-          --build-arg SENTRY_ORG=${{ secrets.SENTRY_ORG }} \
-          --build-arg SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }} \
-          --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          flyctl deploy --remote-only \ --build-arg COMMIT_SHA=${{ github.sha }}
+          \ --build-arg SENTRY_ORG=${{ secrets.SENTRY_ORG }} \ --build-arg
+          SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }} \ --build-secret
+          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/app/components/link-preview-static.tsx
+++ b/app/components/link-preview-static.tsx
@@ -1,72 +1,78 @@
 import { cn } from '#app/utils/misc.tsx'
 
 export interface LinkPreviewStaticProps {
-  url: string
-  title?: string
-  description?: string
-  image?: string
-  domain?: string
-  className?: string
+	url: string
+	title?: string
+	description?: string
+	image?: string
+	domain?: string
+	className?: string
 }
 
 export function LinkPreviewStatic({
-  url,
-  title,
-  description,
-  image,
-  domain,
-  className,
+	url,
+	title,
+	description,
+	image,
+	domain,
+	className,
 }: LinkPreviewStaticProps) {
-  const hasAny = Boolean(title || description || image)
+	const hasAny = Boolean(title || description || image)
 
-  let fallbackHost: string | null = null
-  try {
-    fallbackHost = new URL(url).hostname
-  } catch {
-    fallbackHost = null
-  }
+	let fallbackHost: string | null = null
+	try {
+		fallbackHost = new URL(url).hostname
+	} catch {
+		fallbackHost = null
+	}
 
-  return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        'jdg-link-preview',
-        'group block cursor-pointer overflow-hidden rounded-md border border-primary no-underline transition-shadow focus:border-secondary-foreground',
-        className,
-        !hasAny && 'h-80 sm:h-44',
-      )}
-    >
-      {!hasAny ? (
-        <div className="flex h-full w-full items-center justify-center bg-secondary p-4 dark:bg-secondary/30">
-          <span className="text-sm text-muted-foreground">{fallbackHost ?? 'link'}</span>
-        </div>
-      ) : (
-        <div className="flex flex-col sm:flex-row">
-          {image && (
-            <div className="h-44 flex-shrink-0 sm:h-44 sm:w-44">
-              <img
-                src={image}
-                alt={title || ''}
-                className="h-full w-full object-cover opacity-60 transition-opacity duration-300 group-hover:opacity-100 group-focus:opacity-100"
-                loading="lazy"
-              />
-            </div>
-          )}
-          <div className="p-4">
-            {domain && (
-              <div className="text-sm text-muted-foreground">{domain}</div>
-            )}
-            {title && (
-              <h4 className="mt-2 text-xl font-semibold text-foreground">{title}</h4>
-            )}
-            {description && (
-              <p className="mt-2 line-clamp-2 text-body-sm text-muted-foreground">{description}</p>
-            )}
-          </div>
-        </div>
-      )}
-    </a>
-  )
+	return (
+		<a
+			href={url}
+			target="_blank"
+			rel="noopener noreferrer"
+			className={cn(
+				'jdg-link-preview',
+				'group block cursor-pointer overflow-hidden rounded-md border border-primary no-underline transition-shadow focus:border-secondary-foreground',
+				className,
+				!hasAny && 'h-80 sm:h-44',
+			)}
+		>
+			{!hasAny ? (
+				<div className="flex h-full w-full items-center justify-center bg-secondary p-4 dark:bg-secondary/30">
+					<span className="text-sm text-muted-foreground">
+						{fallbackHost ?? 'link'}
+					</span>
+				</div>
+			) : (
+				<div className="flex flex-col sm:flex-row">
+					{image && (
+						<div className="h-44 flex-shrink-0 sm:h-44 sm:w-44">
+							<img
+								src={image}
+								alt={title || ''}
+								className="h-full w-full object-cover opacity-60 transition-opacity duration-300 group-hover:opacity-100 group-focus:opacity-100"
+								loading="lazy"
+							/>
+						</div>
+					)}
+					<div className="p-4">
+						{domain && (
+							<div className="text-sm text-muted-foreground">{domain}</div>
+						)}
+						{title && (
+							<h4 className="mt-2 text-xl font-semibold text-foreground">
+								{title}
+							</h4>
+						)}
+						{description && (
+							<p className="mt-2 line-clamp-2 text-body-sm text-muted-foreground">
+								{description}
+							</p>
+						)}
+					</div>
+				</div>
+			)}
+		</a>
+	)
 }

--- a/app/components/mdx-image.tsx
+++ b/app/components/mdx-image.tsx
@@ -2,55 +2,60 @@ import { useState } from 'react'
 import { cn } from '#app/utils/misc.tsx'
 
 type MdxImageProps = {
-  src: string
-  alt?: string
-  title?: string
-  className?: string
-  width?: number | string
-  height?: number | string
+	src: string
+	alt?: string
+	title?: string
+	className?: string
+	width?: number | string
+	height?: number | string
 }
 
-export function MdxImage({ src, alt = '', title, className, width, height }: MdxImageProps) {
-  // Compute aspect ratio if we have numeric width/height
-  const w = typeof width === 'string' ? Number(width) : width
-  const h = typeof height === 'string' ? Number(height) : height
-  const hasAspect = Boolean(w && h)
-  const aspect = hasAspect ? `${w} / ${h}` : undefined
+export function MdxImage({
+	src,
+	alt = '',
+	title,
+	className,
+	width,
+	height,
+}: MdxImageProps) {
+	// Compute aspect ratio if we have numeric width/height
+	const w = typeof width === 'string' ? Number(width) : width
+	const h = typeof height === 'string' ? Number(height) : height
+	const hasAspect = Boolean(w && h)
+	const aspect = hasAspect ? `${w} / ${h}` : undefined
 
-  // Client-side loaded state for fade-in and shimmer removal
-  const [loaded, setLoaded] = useState(false)
+	// Client-side loaded state for fade-in and shimmer removal
+	const [loaded, setLoaded] = useState(false)
 
-  // Optionally prefix with ASSET_BASE_URL on the client; on the server, keep relative
-  const resolvedSrc = src
+	// Optionally prefix with ASSET_BASE_URL on the client; on the server, keep relative
+	const resolvedSrc = src
 
-  return (
-    <div
-      className={cn('relative w-full overflow-hidden rounded-md', className)}
-      style={aspect ? { aspectRatio: aspect } : undefined}
-    >
-      {/* Shimmer placeholder */}
-      <div
-        className={cn(
-          'absolute inset-0 animate-pulse bg-secondary/50 dark:bg-secondary/20',
-          loaded && 'hidden',
-        )}
-      />
-      <img
-        src={resolvedSrc}
-        alt={alt}
-        title={title}
-        className={cn(
-          hasAspect
-            ? 'h-full w-full object-contain'
-            : 'w-full h-auto',
-          'opacity-0 transition-opacity duration-300',
-          loaded && 'opacity-100',
-        )}
-        {...(w && h ? { width: w, height: h } : {})}
-        loading="lazy"
-        decoding="async"
-        onLoad={() => setLoaded(true)}
-      />
-    </div>
-  )
+	return (
+		<div
+			className={cn('relative w-full overflow-hidden rounded-md', className)}
+			style={aspect ? { aspectRatio: aspect } : undefined}
+		>
+			{/* Shimmer placeholder */}
+			<div
+				className={cn(
+					'absolute inset-0 animate-pulse bg-secondary/50 dark:bg-secondary/20',
+					loaded && 'hidden',
+				)}
+			/>
+			<img
+				src={resolvedSrc}
+				alt={alt}
+				title={title}
+				className={cn(
+					hasAspect ? 'h-full w-full object-contain' : 'h-auto w-full',
+					'opacity-0 transition-opacity duration-300',
+					loaded && 'opacity-100',
+				)}
+				{...(w && h ? { width: w, height: h } : {})}
+				loading="lazy"
+				decoding="async"
+				onLoad={() => setLoaded(true)}
+			/>
+		</div>
+	)
 }

--- a/app/components/mdx/editor.tsx
+++ b/app/components/mdx/editor.tsx
@@ -39,10 +39,10 @@ import {
 import { type LeafDirective } from 'mdast-util-directive'
 import { useRef } from 'react'
 import { ClientOnly } from 'remix-utils/client-only'
+import { LinkPreviewStatic } from '#app/components/link-preview-static.tsx'
+import { LinkPreview } from '#app/components/link-preview.tsx'
 import { useTheme } from '#app/routes/resources+/theme-switch.tsx'
 import { cn } from '#app/utils/misc.tsx'
-import { LinkPreview } from '#app/components/link-preview.tsx'
-import { LinkPreviewStatic } from '#app/components/link-preview-static.tsx'
 
 type MDXEditorProps = {
 	markdown: string
@@ -63,29 +63,54 @@ const Toolbar = () => (
 				},
 				{
 					fallback: () => (
-						<>
-							<UndoRedo />
+						<div className="mdx-toolbar">
+							{/* History Controls */}
+							<div className="mdx-toolbar-group">
+								<UndoRedo />
+							</div>
 							<Separator />
-							<BoldItalicUnderlineToggles />
-							<CodeToggle />
+							
+							{/* Text Formatting */}
+							<div className="mdx-toolbar-group">
+								<BoldItalicUnderlineToggles />
+								<CodeToggle />
+								<StrikeThroughSupSubToggles />
+							</div>
 							<Separator />
-							<InsertCodeBlock />
+							
+							{/* Block Formatting */}
+							<div className="mdx-toolbar-group">
+								<BlockTypeSelect />
+								<ListsToggle />
+							</div>
 							<Separator />
-							<StrikeThroughSupSubToggles />
+							
+							{/* Code & Structure */}
+							<div className="mdx-toolbar-group">
+								<InsertCodeBlock />
+								<InsertThematicBreak />
+							</div>
 							<Separator />
-							<ListsToggle />
-							<Separator />
-							<BlockTypeSelect />
-							<Separator />
+							
+							{/* Media & Links */}
+							<div className="mdx-toolbar-group">
 								<CreateLink />
 								<InsertImage />
+							</div>
+							<Separator />
+							
+							{/* Rich Content */}
+							<div className="mdx-toolbar-group">
 								<PreviewButton />
 								<YouTubeButton />
-								<Separator />
-								<InsertTable />
-							<InsertThematicBreak />
+							</div>
 							<Separator />
-						</>
+							
+							{/* Tables */}
+							<div className="mdx-toolbar-group">
+								<InsertTable />
+							</div>
+						</div>
 					),
 				},
 			]}
@@ -268,31 +293,31 @@ const YoutubeDirectiveDescriptor: DirectiveDescriptor<YoutubeDirectiveNode> = {
 	hasChildren: false,
 	Editor: ({ mdastNode, lexicalNode, parentEditor }) => {
 		return (
-			<div
-				style={{
-					display: 'flex',
-					flexDirection: 'column',
-					alignItems: 'flex-start',
-				}}
-			>
-				<button
-					onClick={() => {
-						parentEditor.update(() => {
-							lexicalNode.selectNext()
-							lexicalNode.remove()
-						})
-					}}
-				>
-					delete
-				</button>
-				<iframe
-					width="560"
-					height="315"
-					src={`https://www.youtube.com/embed/${mdastNode.attributes.id}`}
-					title="YouTube video player"
-					frameBorder="0"
-					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-				></iframe>
+			<div className="mdx-directive-container">
+				<div className="mdx-directive-controls">
+					<button
+						className="mdx-delete-button"
+						onClick={() => {
+							parentEditor.update(() => {
+								lexicalNode.selectNext()
+								lexicalNode.remove()
+							})
+						}}
+						title="Delete YouTube video"
+					>
+						🗑️
+					</button>
+				</div>
+				<div className="mdx-directive-content">
+					<iframe
+						width="560"
+						height="315"
+						src={`https://www.youtube.com/embed/${mdastNode.attributes.id}`}
+						title="YouTube video player"
+						frameBorder="0"
+						allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					></iframe>
+				</div>
 			</div>
 		)
 	},
@@ -318,23 +343,29 @@ const PreviewDirectiveDescriptor: DirectiveDescriptor<PreviewDirectiveNode> = {
         const image = (mdastNode as any).attributes?.image as string | undefined
         const domain = (mdastNode as any).attributes?.domain as string | undefined
         return (
-            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 8 }}>
-                <button
-                    onClick={() => {
-                        parentEditor.update(() => {
-                            lexicalNode.selectNext()
-                            lexicalNode.remove()
-                        })
-                    }}
-                >
-                    delete
-                </button>
-                <div style={{ maxWidth: 640 }}>
-                    {title || description || image || domain ? (
-                        <LinkPreviewStatic url={url} title={title} description={description} image={image} domain={domain} />
-                    ) : (
-                        <LinkPreview url={url} />
-                    )}
+            <div className="mdx-directive-container">
+                <div className="mdx-directive-controls">
+                    <button
+                        className="mdx-delete-button"
+                        onClick={() => {
+                            parentEditor.update(() => {
+                                lexicalNode.selectNext()
+                                lexicalNode.remove()
+                            })
+                        }}
+                        title="Delete link preview"
+                    >
+                        🗑️
+                    </button>
+                </div>
+                <div className="mdx-directive-content">
+                    <div className="mdx-link-preview-container">
+                        {title || description || image || domain ? (
+                            <LinkPreviewStatic url={url} title={title} description={description} image={image} domain={domain} />
+                        ) : (
+                            <LinkPreview url={url} />
+                        )}
+                    </div>
                 </div>
             </div>
         )

--- a/app/components/mdx/editor.tsx
+++ b/app/components/mdx/editor.tsx
@@ -69,7 +69,7 @@ const Toolbar = () => (
 								<UndoRedo />
 							</div>
 							<Separator />
-							
+
 							{/* Text Formatting */}
 							<div className="mdx-toolbar-group">
 								<BoldItalicUnderlineToggles />
@@ -77,35 +77,35 @@ const Toolbar = () => (
 								<StrikeThroughSupSubToggles />
 							</div>
 							<Separator />
-							
+
 							{/* Block Formatting */}
 							<div className="mdx-toolbar-group">
 								<BlockTypeSelect />
 								<ListsToggle />
 							</div>
 							<Separator />
-							
+
 							{/* Code & Structure */}
 							<div className="mdx-toolbar-group">
 								<InsertCodeBlock />
 								<InsertThematicBreak />
 							</div>
 							<Separator />
-							
+
 							{/* Media & Links */}
 							<div className="mdx-toolbar-group">
 								<CreateLink />
 								<InsertImage />
 							</div>
 							<Separator />
-							
+
 							{/* Rich Content */}
 							<div className="mdx-toolbar-group">
 								<PreviewButton />
 								<YouTubeButton />
 							</div>
 							<Separator />
-							
+
 							{/* Tables */}
 							<div className="mdx-toolbar-group">
 								<InsertTable />
@@ -169,7 +169,7 @@ export function MDXEditorComponent({
 									'': 'Unspecified',
 								},
 							}),
-						directivesPlugin({
+							directivesPlugin({
 								directiveDescriptors: [
 									YoutubeDirectiveDescriptor,
 									PreviewDirectiveDescriptor,
@@ -218,69 +218,84 @@ const YouTubeButton = () => {
 }
 
 const PreviewButton = () => {
-    const insertDirective = usePublisher(insertDirective$)
+	const insertDirective = usePublisher(insertDirective$)
 
-    // Load recent URLs from localStorage for autocomplete
-    let recentSuggestions: string[] = []
-    try {
-        const raw = typeof window !== 'undefined' ? localStorage.getItem('jdg:preview:recent') : null
-        recentSuggestions = raw ? (JSON.parse(raw) as string[]) : []
-    } catch {
-        recentSuggestions = []
-    }
+	// Load recent URLs from localStorage for autocomplete
+	let recentSuggestions: string[] = []
+	try {
+		const raw =
+			typeof window !== 'undefined'
+				? localStorage.getItem('jdg:preview:recent')
+				: null
+		recentSuggestions = raw ? (JSON.parse(raw) as string[]) : []
+	} catch {
+		recentSuggestions = []
+	}
 
-    return (
-        <DialogButton
-            tooltipTitle="Insert Link Preview"
-            submitButtonTitle="Insert preview"
-            dialogInputPlaceholder="Paste the URL to preview"
-            buttonContent="Preview"
-            autocompleteSuggestions={recentSuggestions}
-            onSubmit={(url) => {
-                try {
-                    const u = new URL(url)
-                    if (!/^https?:/.test(u.protocol)) throw new Error('Invalid scheme')
-                } catch {
-                    alert('Please enter a valid http(s) URL')
-                    return
-                }
+	return (
+		<DialogButton
+			tooltipTitle="Insert Link Preview"
+			submitButtonTitle="Insert preview"
+			dialogInputPlaceholder="Paste the URL to preview"
+			buttonContent="Preview"
+			autocompleteSuggestions={recentSuggestions}
+			onSubmit={(url) => {
+				try {
+					const u = new URL(url)
+					if (!/^https?:/.test(u.protocol)) throw new Error('Invalid scheme')
+				} catch {
+					alert('Please enter a valid http(s) URL')
+					return
+				}
 
-                // Optional overrides
-                const title = window.prompt('Optional title override (leave blank to auto-fetch):') || ''
-                const description = window.prompt('Optional description override (leave blank to auto-fetch):') || ''
-                const image = window.prompt('Optional image URL override (leave blank to auto-fetch):') || ''
-                const domain = window.prompt('Optional domain override (leave blank to auto-detect):') || ''
+				// Optional overrides
+				const title =
+					window.prompt(
+						'Optional title override (leave blank to auto-fetch):',
+					) || ''
+				const description =
+					window.prompt(
+						'Optional description override (leave blank to auto-fetch):',
+					) || ''
+				const image =
+					window.prompt(
+						'Optional image URL override (leave blank to auto-fetch):',
+					) || ''
+				const domain =
+					window.prompt(
+						'Optional domain override (leave blank to auto-detect):',
+					) || ''
 
-                const attributes: Record<string, string> = { url }
-                if (title.trim()) attributes.title = title.trim()
-                if (description.trim()) attributes.description = description.trim()
-                if (image.trim()) attributes.image = image.trim()
-                if (domain.trim()) attributes.domain = domain.trim()
+				const attributes: Record<string, string> = { url }
+				if (title.trim()) attributes.title = title.trim()
+				if (description.trim()) attributes.description = description.trim()
+				if (image.trim()) attributes.image = image.trim()
+				if (domain.trim()) attributes.domain = domain.trim()
 
-                insertDirective({
-                    name: 'preview',
-                    type: 'leafDirective',
-                    attributes,
-                    children: [],
-                } as LeafDirective)
+				insertDirective({
+					name: 'preview',
+					type: 'leafDirective',
+					attributes,
+					children: [],
+				} as LeafDirective)
 
-                // Persist recent URL for autocomplete
-                try {
-                    const raw = localStorage.getItem('jdg:preview:recent')
-                    const list: string[] = raw ? (JSON.parse(raw) as string[]) : []
-                    const next = [url, ...list.filter((u) => u !== url)].slice(0, 15)
-                    localStorage.setItem('jdg:preview:recent', JSON.stringify(next))
-                } catch {
-                    // ignore
-                }
-            }}
-        />
-    )
+				// Persist recent URL for autocomplete
+				try {
+					const raw = localStorage.getItem('jdg:preview:recent')
+					const list: string[] = raw ? (JSON.parse(raw) as string[]) : []
+					const next = [url, ...list.filter((u) => u !== url)].slice(0, 15)
+					localStorage.setItem('jdg:preview:recent', JSON.stringify(next))
+				} catch {
+					// ignore
+				}
+			}}
+		/>
+	)
 }
 
 interface YoutubeDirectiveNode extends LeafDirective {
-    name: 'youtube'
-    attributes: { id: string }
+	name: 'youtube'
+	attributes: { id: string }
 }
 
 const YoutubeDirectiveDescriptor: DirectiveDescriptor<YoutubeDirectiveNode> = {
@@ -324,50 +339,58 @@ const YoutubeDirectiveDescriptor: DirectiveDescriptor<YoutubeDirectiveNode> = {
 }
 
 interface PreviewDirectiveNode extends LeafDirective {
-    name: 'preview'
-    attributes: { url: string }
+	name: 'preview'
+	attributes: { url: string }
 }
 
 const PreviewDirectiveDescriptor: DirectiveDescriptor<PreviewDirectiveNode> = {
-    name: 'preview',
-    type: 'leafDirective',
-    testNode(node) {
-        return node.name === 'preview'
-    },
-    attributes: ['url', 'title', 'description', 'image', 'domain'],
-    hasChildren: false,
-    Editor: ({ mdastNode, lexicalNode, parentEditor }) => {
-        const url = mdastNode.attributes.url
-        const title = (mdastNode as any).attributes?.title as string | undefined
-        const description = (mdastNode as any).attributes?.description as string | undefined
-        const image = (mdastNode as any).attributes?.image as string | undefined
-        const domain = (mdastNode as any).attributes?.domain as string | undefined
-        return (
-            <div className="mdx-directive-container">
-                <div className="mdx-directive-controls">
-                    <button
-                        className="mdx-delete-button"
-                        onClick={() => {
-                            parentEditor.update(() => {
-                                lexicalNode.selectNext()
-                                lexicalNode.remove()
-                            })
-                        }}
-                        title="Delete link preview"
-                    >
-                        🗑️
-                    </button>
-                </div>
-                <div className="mdx-directive-content">
-                    <div className="mdx-link-preview-container">
-                        {title || description || image || domain ? (
-                            <LinkPreviewStatic url={url} title={title} description={description} image={image} domain={domain} />
-                        ) : (
-                            <LinkPreview url={url} />
-                        )}
-                    </div>
-                </div>
-            </div>
-        )
-    },
+	name: 'preview',
+	type: 'leafDirective',
+	testNode(node) {
+		return node.name === 'preview'
+	},
+	attributes: ['url', 'title', 'description', 'image', 'domain'],
+	hasChildren: false,
+	Editor: ({ mdastNode, lexicalNode, parentEditor }) => {
+		const url = mdastNode.attributes.url
+		const title = (mdastNode as any).attributes?.title as string | undefined
+		const description = (mdastNode as any).attributes?.description as
+			| string
+			| undefined
+		const image = (mdastNode as any).attributes?.image as string | undefined
+		const domain = (mdastNode as any).attributes?.domain as string | undefined
+		return (
+			<div className="mdx-directive-container">
+				<div className="mdx-directive-controls">
+					<button
+						className="mdx-delete-button"
+						onClick={() => {
+							parentEditor.update(() => {
+								lexicalNode.selectNext()
+								lexicalNode.remove()
+							})
+						}}
+						title="Delete link preview"
+					>
+						🗑️
+					</button>
+				</div>
+				<div className="mdx-directive-content">
+					<div className="mdx-link-preview-container">
+						{title || description || image || domain ? (
+							<LinkPreviewStatic
+								url={url}
+								title={title}
+								description={description}
+								image={image}
+								domain={domain}
+							/>
+						) : (
+							<LinkPreview url={url} />
+						)}
+					</div>
+				</div>
+			</div>
+		)
+	},
 }

--- a/app/routes/admin+/fragments+/create.tsx
+++ b/app/routes/admin+/fragments+/create.tsx
@@ -143,10 +143,14 @@ export default function NewPost() {
 	}, [content])
 
 	return (
-		<div className="p-8">
-			<h1 className="mb-6 text-2xl font-bold">New Post</h1>
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto max-w-4xl p-6 space-y-8">
+				<div className="space-y-2">
+					<h1 className="text-3xl font-bold">New Post</h1>
+					<p className="text-muted-foreground">Create a new blog post or fragment</p>
+				</div>
 
-			<Form method="post" {...getFormProps(form)} className="mb-12 space-y-6">
+				<Form method="post" {...getFormProps(form)} className="space-y-8">
 				<Field
 					labelProps={{
 						htmlFor: fields.title.id,
@@ -189,15 +193,15 @@ export default function NewPost() {
 					errors={fields.publishAt.errors}
 				/>
 
-				<div>
-					<label className="mb-1 block text-sm font-medium">Content</label>
-					<div className="rounded-md border">
+				<div className="space-y-3">
+					<label className="block text-sm font-medium">Content</label>
+					<div className="rounded-lg border border-input bg-background shadow-sm">
 						<MDXEditorComponent
 							images={images.map((image) => getPostImageSource(image.id))}
 							imageUploadHandler={handleImageUpload}
 							markdown={content}
 							onChange={setContent}
-							className="min-h-[400px]"
+							className="min-h-[500px]"
 						/>
 					</div>
 					<textarea
@@ -224,11 +228,18 @@ export default function NewPost() {
 				</StatusButton>
 			</Form>
 
-			<h2>Manage post images</h2>
-			<PostImageManager images={images} />
+				<div className="space-y-6">
+					<div className="space-y-4">
+						<h2 className="text-xl font-semibold">Manage Images</h2>
+						<PostImageManager images={images} />
+					</div>
 
-			<h2>Manage post videos</h2>
-			<PostVideoManager videos={videos} />
+					<div className="space-y-4">
+						<h2 className="text-xl font-semibold">Manage Videos</h2>
+						<PostVideoManager videos={videos} />
+					</div>
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/app/routes/admin+/fragments+/create.tsx
+++ b/app/routes/admin+/fragments+/create.tsx
@@ -85,20 +85,20 @@ export async function action({ request }: Route.ActionArgs) {
 		? fromZonedTime(publishAt, timeZone)
 		: null
 
-    try {
-        const created = await prisma.post.create({
-            data: {
-                title,
-                content,
-                description,
-                slug: makePostSlug(title, slug),
-                publishAt: publishAtWithTimezone,
-                authorId,
-            },
-        })
+	try {
+		const created = await prisma.post.create({
+			data: {
+				title,
+				content,
+				description,
+				slug: makePostSlug(title, slug),
+				publishAt: publishAtWithTimezone,
+				authorId,
+			},
+		})
 
-        // Warm compiled MDX & inline previews (non-blocking)
-        void compileMDX(content, { title })
+		// Warm compiled MDX & inline previews (non-blocking)
+		void compileMDX(content, { title })
 
 		return redirectWithToast('/admin/fragments', {
 			title: 'Post created',
@@ -144,89 +144,91 @@ export default function NewPost() {
 
 	return (
 		<div className="min-h-screen bg-background">
-			<div className="container mx-auto max-w-4xl p-6 space-y-8">
+			<div className="container mx-auto max-w-4xl space-y-8 p-6">
 				<div className="space-y-2">
 					<h1 className="text-3xl font-bold">New Post</h1>
-					<p className="text-muted-foreground">Create a new blog post or fragment</p>
+					<p className="text-muted-foreground">
+						Create a new blog post or fragment
+					</p>
 				</div>
 
 				<Form method="post" {...getFormProps(form)} className="space-y-8">
-				<Field
-					labelProps={{
-						htmlFor: fields.title.id,
-						children: 'Title',
-					}}
-					inputProps={{
-						...getInputProps(fields.title, { type: 'text' }),
-					}}
-					errors={fields.title.errors}
-				/>
-				<Field
-					labelProps={{
-						htmlFor: fields.description.id,
-						children: 'Description',
-					}}
-					inputProps={{
-						...getInputProps(fields.description, { type: 'text' }),
-					}}
-					errors={fields.description.errors}
-				/>
-				<Field
-					labelProps={{
-						htmlFor: fields.slug.id,
-						children: 'Slug (optional - defaults to kebab-cased title)',
-					}}
-					inputProps={{
-						...getInputProps(fields.slug, { type: 'text' }),
-					}}
-					errors={fields.slug.errors}
-				/>
-				<Field
-					labelProps={{
-						htmlFor: fields.publishAt.id,
-						children:
-							'When should this post be published? (optional - defaults to now)',
-					}}
-					inputProps={{
-						...getInputProps(fields.publishAt, { type: 'datetime-local' }),
-					}}
-					errors={fields.publishAt.errors}
-				/>
-
-				<div className="space-y-3">
-					<label className="block text-sm font-medium">Content</label>
-					<div className="rounded-lg border border-input bg-background shadow-sm">
-						<MDXEditorComponent
-							images={images.map((image) => getPostImageSource(image.id))}
-							imageUploadHandler={handleImageUpload}
-							markdown={content}
-							onChange={setContent}
-							className="min-h-[500px]"
-						/>
-					</div>
-					<textarea
-						ref={contentRef}
-						{...getTextareaProps(fields.content)}
-						className="hidden"
+					<Field
+						labelProps={{
+							htmlFor: fields.title.id,
+							children: 'Title',
+						}}
+						inputProps={{
+							...getInputProps(fields.title, { type: 'text' }),
+						}}
+						errors={fields.title.errors}
 					/>
-					{fields.content.errors ? (
-						<div className="text-sm text-destructive">
-							{fields.content.errors}
+					<Field
+						labelProps={{
+							htmlFor: fields.description.id,
+							children: 'Description',
+						}}
+						inputProps={{
+							...getInputProps(fields.description, { type: 'text' }),
+						}}
+						errors={fields.description.errors}
+					/>
+					<Field
+						labelProps={{
+							htmlFor: fields.slug.id,
+							children: 'Slug (optional - defaults to kebab-cased title)',
+						}}
+						inputProps={{
+							...getInputProps(fields.slug, { type: 'text' }),
+						}}
+						errors={fields.slug.errors}
+					/>
+					<Field
+						labelProps={{
+							htmlFor: fields.publishAt.id,
+							children:
+								'When should this post be published? (optional - defaults to now)',
+						}}
+						inputProps={{
+							...getInputProps(fields.publishAt, { type: 'datetime-local' }),
+						}}
+						errors={fields.publishAt.errors}
+					/>
+
+					<div className="space-y-3">
+						<label className="block text-sm font-medium">Content</label>
+						<div className="rounded-lg border border-input bg-background shadow-sm">
+							<MDXEditorComponent
+								images={images.map((image) => getPostImageSource(image.id))}
+								imageUploadHandler={handleImageUpload}
+								markdown={content}
+								onChange={setContent}
+								className="min-h-[500px]"
+							/>
 						</div>
-					) : null}
-				</div>
+						<textarea
+							ref={contentRef}
+							{...getTextareaProps(fields.content)}
+							className="hidden"
+						/>
+						{fields.content.errors ? (
+							<div className="text-sm text-destructive">
+								{fields.content.errors}
+							</div>
+						) : null}
+					</div>
 
-				<ErrorList errors={form.errors} id={form.errorId} />
+					<ErrorList errors={form.errors} id={form.errorId} />
 
-				<StatusButton
-					type="submit"
-					status={isPending ? 'pending' : (form.status ?? 'idle')}
-					disabled={isPending}
-					className="w-full"
-				>
-					Create Post
-				</StatusButton>
-			</Form>
+					<StatusButton
+						type="submit"
+						status={isPending ? 'pending' : (form.status ?? 'idle')}
+						disabled={isPending}
+						className="w-full"
+					>
+						Create Post
+					</StatusButton>
+				</Form>
 
 				<div className="space-y-6">
 					<div className="space-y-4">

--- a/app/routes/admin+/fragments+/delete.tsx
+++ b/app/routes/admin+/fragments+/delete.tsx
@@ -4,18 +4,22 @@ import { prisma } from '#app/utils/db.server.ts'
 import { invalidatePostCaches } from '#app/utils/preview-utils.server.ts'
 
 export async function action({ request }: ActionFunctionArgs) {
-    const formData = await request.formData()
-    const id = formData.get('postId')
+	const formData = await request.formData()
+	const id = formData.get('postId')
 
 	invariantResponse(typeof id === 'string', 'Invalid request', { status: 400 })
 
-    const existing = await prisma.post.findUnique({ where: { id } })
-    const deleted = await prisma.post.delete({ where: { id } })
+	const existing = await prisma.post.findUnique({ where: { id } })
+	const deleted = await prisma.post.delete({ where: { id } })
 
-    invariantResponse(deleted, 'Not found', { status: 404 })
+	invariantResponse(deleted, 'Not found', { status: 404 })
 
-    // Invalidate caches related to this post
-    await invalidatePostCaches(existing?.content ?? undefined, undefined, existing?.title ?? undefined)
+	// Invalidate caches related to this post
+	await invalidatePostCaches(
+		existing?.content ?? undefined,
+		undefined,
+		existing?.title ?? undefined,
+	)
 
-    return deleted
+	return deleted
 }

--- a/app/routes/admin+/fragments+/edit.$id.tsx
+++ b/app/routes/admin+/fragments+/edit.$id.tsx
@@ -103,32 +103,32 @@ export async function action({ request, params }: Route.ActionArgs) {
 
 	const published = publishAtWithTimezone ?? existingPost?.publishAt ?? null
 
-    try {
-        await prisma.post.update({
-            where: { id: params.id },
-            data: {
-                title,
-                content,
-                description,
-                slug,
-                publishAt: published,
-            },
-        })
+	try {
+		await prisma.post.update({
+			where: { id: params.id },
+			data: {
+				title,
+				content,
+				description,
+				slug,
+				publishAt: published,
+			},
+		})
 
-        // Invalidate caches related to this post (old content and new content URLs)
-        await invalidatePostCaches(
-            existingPost?.content ?? undefined,
-            content,
-            existingPost?.title ?? undefined,
-            title,
-        )
-        // Warm new compiled MDX & inline previews (non-blocking)
-        void compileMDX(content, { title })
+		// Invalidate caches related to this post (old content and new content URLs)
+		await invalidatePostCaches(
+			existingPost?.content ?? undefined,
+			content,
+			existingPost?.title ?? undefined,
+			title,
+		)
+		// Warm new compiled MDX & inline previews (non-blocking)
+		void compileMDX(content, { title })
 
-        return redirectWithToast('/admin/fragments', {
-            title: 'Post updated',
-            description: `Post "${title}" updated successfully.`,
-        })
+		return redirectWithToast('/admin/fragments', {
+			title: 'Post updated',
+			description: `Post "${title}" updated successfully.`,
+		})
 	} catch {
 		return data(
 			{ result: submission.reply({ formErrors: ['Failed to update post'] }) },
@@ -183,102 +183,104 @@ export default function EditPost() {
 
 	return (
 		<div className="min-h-screen bg-background">
-			<div className="container mx-auto max-w-4xl p-6 space-y-8">
+			<div className="container mx-auto max-w-4xl space-y-8 p-6">
 				<div className="space-y-2">
 					<h1 className="text-3xl font-bold">Edit Post</h1>
-					<p className="text-muted-foreground">Update your blog post or fragment</p>
+					<p className="text-muted-foreground">
+						Update your blog post or fragment
+					</p>
 				</div>
 
 				<Form method="post" {...getFormProps(form)} className="space-y-8">
-				<Field
-					labelProps={{
-						htmlFor: fields.title.id,
-						children: 'Title',
-					}}
-					inputProps={{
-						...getInputProps(fields.title, { type: 'text' }),
-					}}
-					errors={fields.title.errors}
-				/>
-				<Field
-					labelProps={{
-						htmlFor: fields.description.id,
-						children: 'Description',
-					}}
-					inputProps={{
-						...getInputProps(fields.description, { type: 'text' }),
-					}}
-					errors={fields.description.errors}
-				/>
-				<Field
-					labelProps={{
-						htmlFor: fields.slug.id,
-						children: 'Slug',
-					}}
-					inputProps={{
-						...getInputProps(fields.slug, { type: 'text' }),
-					}}
-					errors={fields.slug.errors}
-				/>
-				{post.publishAt && !showDateField && (
-					<Button
-						variant="outline"
-						type="button"
-						onClick={() => setShowDateField(true)}
-					>
-						Post is published. Edit the publish date?
-					</Button>
-				)}
-				{(showDateField || !post.publishAt) && (
 					<Field
 						labelProps={{
-							htmlFor: fields.publishAt.id,
-							children: 'Update publish date',
+							htmlFor: fields.title.id,
+							children: 'Title',
 						}}
 						inputProps={{
-							...getInputProps(fields.publishAt, { type: 'datetime-local' }),
+							...getInputProps(fields.title, { type: 'text' }),
 						}}
-						errors={fields.publishAt.errors}
+						errors={fields.title.errors}
 					/>
-				)}
-
-				<div className="space-y-3">
-					<label className="block text-sm font-medium">Content</label>
-					<div className="rounded-lg border border-input bg-background shadow-sm">
-						<MDXEditorComponent
-							imageUploadHandler={handleImageUpload}
-							images={images.map((image) => getPostImageSource(image.id))}
-							markdown={content}
-							onChange={setContent}
-							diffSource={post.content}
-							className="min-h-[500px]"
+					<Field
+						labelProps={{
+							htmlFor: fields.description.id,
+							children: 'Description',
+						}}
+						inputProps={{
+							...getInputProps(fields.description, { type: 'text' }),
+						}}
+						errors={fields.description.errors}
+					/>
+					<Field
+						labelProps={{
+							htmlFor: fields.slug.id,
+							children: 'Slug',
+						}}
+						inputProps={{
+							...getInputProps(fields.slug, { type: 'text' }),
+						}}
+						errors={fields.slug.errors}
+					/>
+					{post.publishAt && !showDateField && (
+						<Button
+							variant="outline"
+							type="button"
+							onClick={() => setShowDateField(true)}
+						>
+							Post is published. Edit the publish date?
+						</Button>
+					)}
+					{(showDateField || !post.publishAt) && (
+						<Field
+							labelProps={{
+								htmlFor: fields.publishAt.id,
+								children: 'Update publish date',
+							}}
+							inputProps={{
+								...getInputProps(fields.publishAt, { type: 'datetime-local' }),
+							}}
+							errors={fields.publishAt.errors}
 						/>
-					</div>
-					<textarea
-						ref={contentRef}
-						{...getTextareaProps(fields.content)}
-						className="hidden"
-					/>
-					{fields.content.errors ? (
-						<div className="text-sm text-destructive">
-							{fields.content.errors}
+					)}
+
+					<div className="space-y-3">
+						<label className="block text-sm font-medium">Content</label>
+						<div className="rounded-lg border border-input bg-background shadow-sm">
+							<MDXEditorComponent
+								imageUploadHandler={handleImageUpload}
+								images={images.map((image) => getPostImageSource(image.id))}
+								markdown={content}
+								onChange={setContent}
+								diffSource={post.content}
+								className="min-h-[500px]"
+							/>
 						</div>
-					) : null}
-				</div>
+						<textarea
+							ref={contentRef}
+							{...getTextareaProps(fields.content)}
+							className="hidden"
+						/>
+						{fields.content.errors ? (
+							<div className="text-sm text-destructive">
+								{fields.content.errors}
+							</div>
+						) : null}
+					</div>
 
-				<ErrorList errors={form.errors} id={form.errorId} />
+					<ErrorList errors={form.errors} id={form.errorId} />
 
-				<div className="flex gap-4">
-					<StatusButton
-						type="submit"
-						status={isPending ? 'pending' : (form.status ?? 'idle')}
-						disabled={isPending}
-						className="w-full"
-					>
-						Save Changes
-					</StatusButton>
-				</div>
-			</Form>
+					<div className="flex gap-4">
+						<StatusButton
+							type="submit"
+							status={isPending ? 'pending' : (form.status ?? 'idle')}
+							disabled={isPending}
+							className="w-full"
+						>
+							Save Changes
+						</StatusButton>
+					</div>
+				</Form>
 
 				<div className="space-y-6">
 					<div className="space-y-4">

--- a/app/routes/admin+/fragments+/edit.$id.tsx
+++ b/app/routes/admin+/fragments+/edit.$id.tsx
@@ -182,10 +182,14 @@ export default function EditPost() {
 	}, [content])
 
 	return (
-		<div className="p-8">
-			<h1 className="mb-6 text-2xl font-bold">Edit Post</h1>
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto max-w-4xl p-6 space-y-8">
+				<div className="space-y-2">
+					<h1 className="text-3xl font-bold">Edit Post</h1>
+					<p className="text-muted-foreground">Update your blog post or fragment</p>
+				</div>
 
-			<Form method="post" {...getFormProps(form)} className="space-y-6">
+				<Form method="post" {...getFormProps(form)} className="space-y-8">
 				<Field
 					labelProps={{
 						htmlFor: fields.title.id,
@@ -238,15 +242,16 @@ export default function EditPost() {
 					/>
 				)}
 
-				<div>
-					<label className="mb-1 block text-sm font-medium">Content</label>
-					<div className="border">
+				<div className="space-y-3">
+					<label className="block text-sm font-medium">Content</label>
+					<div className="rounded-lg border border-input bg-background shadow-sm">
 						<MDXEditorComponent
 							imageUploadHandler={handleImageUpload}
 							images={images.map((image) => getPostImageSource(image.id))}
 							markdown={content}
 							onChange={setContent}
 							diffSource={post.content}
+							className="min-h-[500px]"
 						/>
 					</div>
 					<textarea
@@ -275,11 +280,18 @@ export default function EditPost() {
 				</div>
 			</Form>
 
-			<h2>Manage post images</h2>
-			<PostImageManager images={images} />
+				<div className="space-y-6">
+					<div className="space-y-4">
+						<h2 className="text-xl font-semibold">Manage Images</h2>
+						<PostImageManager images={images} />
+					</div>
 
-			<h2>Manage post videos</h2>
-			<PostVideoManager videos={videos} />
+					<div className="space-y-4">
+						<h2 className="text-xl font-semibold">Manage Videos</h2>
+						<PostVideoManager videos={videos} />
+					</div>
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/app/routes/admin+/fragments+/images.create.tsx
+++ b/app/routes/admin+/fragments+/images.create.tsx
@@ -3,9 +3,15 @@ import { type FileUpload, parseFormData } from '@mjackson/form-data-parser'
 import { data } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server'
-import { getImageDimensions, resizeImage } from '#app/utils/image-processing.server.ts'
+import {
+	getImageDimensions,
+	resizeImage,
+} from '#app/utils/image-processing.server.ts'
 import { getPostImageSource } from '#app/utils/misc.tsx'
-import { getSignedUploadUrl, IMMUTABLE_CACHE_CONTROL } from '#app/utils/s3.server.ts'
+import {
+	getSignedUploadUrl,
+	IMMUTABLE_CACHE_CONTROL,
+} from '#app/utils/s3.server.ts'
 import { type Route } from './+types/images.create'
 
 const MAX_UPLOAD_SIZE = 1024 * 1024 * 10 // 10MB
@@ -23,17 +29,17 @@ export async function action({ request }: Route.ActionArgs) {
 			return fileStorage.get(storageKey)
 		}
 
-        if (fileUpload.fieldName === 'file') {
-            // Convert upload to buffer for processing
-            const buffer = await fileUpload.arrayBuffer()
-            // Resize to max 800px (post container max width)
-            const inputBuffer = Buffer.from(buffer)
-            const resizedImageBuffer = await resizeImage(inputBuffer)
+		if (fileUpload.fieldName === 'file') {
+			// Convert upload to buffer for processing
+			const buffer = await fileUpload.arrayBuffer()
+			// Resize to max 800px (post container max width)
+			const inputBuffer = Buffer.from(buffer)
+			const resizedImageBuffer = await resizeImage(inputBuffer)
 
-            // Create a new File object with the resized image
-            const resizedFile = new File([resizedImageBuffer], fileUpload.name, {
-                type: fileUpload.type,
-            })
+			// Create a new File object with the resized image
+			const resizedFile = new File([resizedImageBuffer], fileUpload.name, {
+				type: fileUpload.type,
+			})
 
 			await fileStorage.set(storageKey, resizedFile)
 			return fileStorage.get(storageKey)
@@ -59,34 +65,34 @@ export async function action({ request }: Route.ActionArgs) {
 		return data({ error: 'Alt text is required' }, { status: 400 })
 	}
 
-    try {
-        const key = `images/${Date.now()}-${file.name}`
-        const uploadUrl = await getSignedUploadUrl(key, file.type)
+	try {
+		const key = `images/${Date.now()}-${file.name}`
+		const uploadUrl = await getSignedUploadUrl(key, file.type)
 
-        // Determine dimensions of the file we will upload (resized or original if gif)
-        const arrayBuf = await file.arrayBuffer()
-        const { width, height } = await getImageDimensions(Buffer.from(arrayBuf))
+		// Determine dimensions of the file we will upload (resized or original if gif)
+		const arrayBuf = await file.arrayBuffer()
+		const { width, height } = await getImageDimensions(Buffer.from(arrayBuf))
 
-        const image = await prisma.postImage.create({
-            data: {
-                s3Key: key,
-                contentType: file.type,
-                altText: formData.get('altText') as string,
-                title: formData.get('title') as string,
-                width: width ?? null,
-                height: height ?? null,
-            },
-        })
+		const image = await prisma.postImage.create({
+			data: {
+				s3Key: key,
+				contentType: file.type,
+				altText: formData.get('altText') as string,
+				title: formData.get('title') as string,
+				width: width ?? null,
+				height: height ?? null,
+			},
+		})
 
 		if (image) {
-            await fetch(uploadUrl, {
-                method: 'PUT',
-                body: file,
-                headers: {
-                    'Content-Type': file.type,
-                    'Cache-Control': IMMUTABLE_CACHE_CONTROL,
-                },
-            })
+			await fetch(uploadUrl, {
+				method: 'PUT',
+				body: file,
+				headers: {
+					'Content-Type': file.type,
+					'Cache-Control': IMMUTABLE_CACHE_CONTROL,
+				},
+			})
 		}
 
 		return getPostImageSource(image.id)

--- a/app/routes/admin+/fragments+/videos.create.tsx
+++ b/app/routes/admin+/fragments+/videos.create.tsx
@@ -3,7 +3,10 @@ import { prisma } from '#app/utils/db.server.ts'
 import { getPostVideoSource } from '#app/utils/misc.tsx'
 import { requireUserWithRole } from '#app/utils/permissions.server.ts'
 import { fileToBlob } from '#app/utils/post-images.server'
-import { getSignedUploadUrl, IMMUTABLE_CACHE_CONTROL } from '#app/utils/s3.server.ts'
+import {
+	getSignedUploadUrl,
+	IMMUTABLE_CACHE_CONTROL,
+} from '#app/utils/s3.server.ts'
 import { type Route } from './+types/videos.create'
 
 export async function action({ request }: Route.ActionArgs) {
@@ -32,14 +35,14 @@ export async function action({ request }: Route.ActionArgs) {
 		})
 
 		if (video) {
-        await fetch(uploadUrl, {
-            method: 'PUT',
-            body: file,
-            headers: {
-                'Content-Type': file.type,
-                'Cache-Control': IMMUTABLE_CACHE_CONTROL,
-            },
-        })
+			await fetch(uploadUrl, {
+				method: 'PUT',
+				body: file,
+				headers: {
+					'Content-Type': file.type,
+					'Cache-Control': IMMUTABLE_CACHE_CONTROL,
+				},
+			})
 		}
 
 		return getPostVideoSource(video.id)

--- a/app/routes/fragments+/__pagination-bar.tsx
+++ b/app/routes/fragments+/__pagination-bar.tsx
@@ -54,7 +54,6 @@ export function PaginationBar({ total }: { total: number }) {
 						skip: 0,
 					}),
 				}}
-				preventScrollReset
 				prefetch="intent"
 				className={cn(
 					paginationButtonClasses,
@@ -71,7 +70,6 @@ export function PaginationBar({ total }: { total: number }) {
 						skip: Math.max(skip - top, 0),
 					}),
 				}}
-				preventScrollReset
 				prefetch="intent"
 				className={cn(
 					paginationButtonClasses,
@@ -106,7 +104,6 @@ export function PaginationBar({ total }: { total: number }) {
 									skip: pageSkip,
 								}),
 							}}
-							preventScrollReset
 							prefetch="intent"
 							className={paginationButtonClasses}
 						>
@@ -121,7 +118,6 @@ export function PaginationBar({ total }: { total: number }) {
 						skip: skip + top,
 					}),
 				}}
-				preventScrollReset
 				prefetch="intent"
 				className={cn(
 					paginationButtonClasses,
@@ -137,7 +133,6 @@ export function PaginationBar({ total }: { total: number }) {
 						skip: (totalPages - 1) * top,
 					}),
 				}}
-				preventScrollReset
 				prefetch="intent"
 				className={cn(
 					paginationButtonClasses,

--- a/app/routes/fragments+/_index.tsx
+++ b/app/routes/fragments+/_index.tsx
@@ -41,7 +41,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 	// Bundle MDX for each post
 	const postsWithMDX = await Promise.all(
 		posts.map(async (post) => {
-			const { code, frontmatter } = await compileMDX(post.content, { title: post.title })
+			const { code, frontmatter } = await compileMDX(post.content, {
+				title: post.title,
+			})
 			return {
 				...post,
 				code,

--- a/app/routes/fragments+/_index.tsx
+++ b/app/routes/fragments+/_index.tsx
@@ -1,6 +1,6 @@
 import { getMDXComponent } from 'mdx-bundler/client'
-import { useMemo } from 'react'
-import { Link, useLoaderData } from 'react-router'
+import { useEffect, useMemo, useRef } from 'react'
+import { Link, useLoaderData, useLocation } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { mdxComponents } from '#app/components/mdx/index.tsx'
 import { prisma } from '#app/utils/db.server'
@@ -89,6 +89,17 @@ function PostContent({ code }: { code: string }) {
 
 export default function Fragments() {
 	const { posts, total } = useLoaderData<typeof loader>()
+	const location = useLocation()
+	const isFirstRender = useRef(true)
+
+	// Ensure we scroll to the top whenever pagination (query) changes
+	useEffect(() => {
+		if (isFirstRender.current) {
+			isFirstRender.current = false
+			return
+		}
+		window.scrollTo({ top: 0, behavior: 'auto' })
+	}, [location.search])
 
 	return (
 		<div className="jdg_typography mx-auto w-full max-w-screen-md p-8">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -16,7 +16,7 @@ export const RECENT_PUBLICATIONS = [
 ]
 
 export async function loader() {
-    const recentFragments = await prisma.post.findMany({
+	const recentFragments = await prisma.post.findMany({
 		where: {
 			publishAt: {
 				not: null,
@@ -41,7 +41,9 @@ export async function loader() {
 					return await getOpenGraphData(url)
 				},
 			})
-			const domain = url.startsWith('data:') ? 'data-url' : new URL(url).hostname
+			const domain = url.startsWith('data:')
+				? 'data-url'
+				: new URL(url).hostname
 			return {
 				url,
 				title: og.title,
@@ -52,7 +54,11 @@ export async function loader() {
 		}),
 	)
 
-	return { fragments: recentFragments, recentPubs: RECENT_PUBLICATIONS, previews }
+	return {
+		fragments: recentFragments,
+		recentPubs: RECENT_PUBLICATIONS,
+		previews,
+	}
 }
 
 export default function Index() {

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -436,7 +436,7 @@
 }
 
 /* Style the toolbar buttons more consistently */
-.mdx-toolbar [data-orientation="vertical"] {
+.mdx-toolbar [data-orientation='vertical'] {
 	display: none; /* Hide vertical separators in our custom layout */
 }
 

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -299,6 +299,160 @@
 	--baseTextContrast: var(var(--neutral-4));
 }
 
+/* MDX Editor Toolbar Styling */
+.mdx-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 1rem;
+	background: hsl(var(--muted) / 0.5);
+	border-bottom: 1px solid hsl(var(--border));
+	border-radius: 0.5rem 0.5rem 0 0;
+	backdrop-filter: blur(8px);
+}
+
+.mdx-toolbar-group {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.25rem;
+	background: hsl(var(--background) / 0.8);
+	border-radius: 0.375rem;
+	border: 1px solid hsl(var(--border) / 0.5);
+	transition: all 0.2s ease-in-out;
+}
+
+.mdx-toolbar-group:hover {
+	background: hsl(var(--background));
+	border-color: hsl(var(--border));
+	box-shadow: 0 2px 4px hsl(var(--foreground) / 0.1);
+}
+
+/* Improve button spacing within groups */
+.mdx-toolbar-group button {
+	margin: 0 0.125rem;
+}
+
+/* Better separator styling */
+.mdx-toolbar .mdxeditor-toolbar-separator {
+	width: 1px;
+	height: 1.5rem;
+	background: hsl(var(--border));
+	margin: 0 0.25rem;
+}
+
+/* Force MDX Editor toggle groups to be horizontal - target by data attributes */
+.mdx-toolbar-group > div[data-toolbar-item] {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+/* Alternative approach - target any div that contains multiple toolbar items */
+.mdx-toolbar-group > div:has([data-toolbar-item]) {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+/* MDX Directive Container Styling */
+.mdx-directive-container {
+	position: relative;
+	margin: 1rem 0;
+	background: hsl(var(--card));
+	overflow: hidden;
+}
+
+.mdx-directive-controls {
+	position: absolute;
+	top: 0.5rem;
+	right: 0.5rem;
+	z-index: 10;
+	opacity: 0;
+	transition: opacity 0.2s ease-in-out;
+}
+
+.mdx-directive-container:hover .mdx-directive-controls {
+	opacity: 1;
+}
+
+.mdx-delete-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	padding: 0;
+	background: hsl(var(--destructive));
+	color: hsl(var(--destructive-foreground));
+	border: none;
+	border-radius: 0.375rem;
+	cursor: pointer;
+	font-size: 0.875rem;
+	transition: all 0.2s ease-in-out;
+}
+
+.mdx-delete-button:hover {
+	background: hsl(var(--destructive) / 0.9);
+	transform: scale(1.05);
+}
+
+.mdx-delete-button:active {
+	transform: scale(0.95);
+}
+
+/* .mdx-directive-content {
+	padding: 1rem;
+} */
+
+.mdx-link-preview-container {
+	width: auto;
+	max-width: 100%;
+	margin: 0 auto;
+}
+
+/* Ensure proper spacing for directives in content */
+/* .jdg_typography .mdx-directive-container {
+	@apply my-6;
+} */
+
+/* Additional toolbar button styling */
+.mdx-toolbar button {
+	position: relative;
+	transition: all 0.2s ease-in-out;
+	border-radius: 0.25rem;
+}
+
+.mdx-toolbar button:hover {
+	transform: translateY(-1px);
+	box-shadow: 0 2px 4px hsl(var(--foreground) / 0.1);
+}
+
+.mdx-toolbar button:active {
+	transform: translateY(0);
+}
+
+/* Style the toolbar buttons more consistently */
+.mdx-toolbar [data-orientation="vertical"] {
+	display: none; /* Hide vertical separators in our custom layout */
+}
+
+/* Improve dropdown styling */
+.mdx-toolbar select {
+	background: hsl(var(--background));
+	border: 1px solid hsl(var(--border));
+	border-radius: 0.25rem;
+	padding: 0.25rem 0.5rem;
+	font-size: 0.875rem;
+}
+
+.mdxeditor-diff-source-wrapper {
+	padding: 24px;
+}
+
 /* MDX editor vars https://github.com/mdx-editor/editor/blob/main/src/examples/dark-editor.css */
 /* .dark {
   --accentBase: var(--tomato-1);

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -9,6 +9,7 @@ const schema = z.object({
 	HONEYPOT_SECRET: z.string(),
 	CACHE_DATABASE_PATH: z.string(),
 	SENTRY_DSN: z.string(),
+	COMMIT_SHA: z.string().optional(),
 	RESEND_API_KEY: z.string(),
 	// If you plan to use GitHub auth, remove the default:
 	GITHUB_CLIENT_ID: z.string().default('MOCK_GITHUB_CLIENT_ID'),
@@ -53,6 +54,7 @@ export function getEnv() {
 	return {
 		MODE: process.env.NODE_ENV,
 		SENTRY_DSN: process.env.SENTRY_DSN ?? '',
+		COMMIT_SHA: process.env.COMMIT_SHA ?? '',
 		ALLOW_INDEXING: process.env.ALLOW_INDEXING ?? 'true',
 		ASSET_BASE_URL: process.env.ASSET_BASE_URL ?? '',
 	}

--- a/app/utils/image-processing.server.ts
+++ b/app/utils/image-processing.server.ts
@@ -1,16 +1,18 @@
 import sharp from 'sharp'
 
 export async function resizeImage(buffer: Buffer): Promise<Buffer> {
-    return sharp(buffer)
-        .resize({
-            width: 1600,
-            withoutEnlargement: true, // This prevents upscaling of smaller images
-            fit: 'inside', // This maintains aspect ratio
-        })
-        .toBuffer()
+	return sharp(buffer)
+		.resize({
+			width: 1600,
+			withoutEnlargement: true, // This prevents upscaling of smaller images
+			fit: 'inside', // This maintains aspect ratio
+		})
+		.toBuffer()
 }
 
-export async function getImageDimensions(buffer: Buffer): Promise<{ width?: number; height?: number }> {
-    const meta = await sharp(buffer).metadata()
-    return { width: meta.width, height: meta.height }
+export async function getImageDimensions(
+	buffer: Buffer,
+): Promise<{ width?: number; height?: number }> {
+	const meta = await sharp(buffer).metadata()
+	return { width: meta.width, height: meta.height }
 }

--- a/app/utils/monitoring.client.tsx
+++ b/app/utils/monitoring.client.tsx
@@ -44,10 +44,10 @@ export function init() {
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
-		tracesSampleRate: .1,
+		tracesSampleRate: 0.1,
 
 		// Enable browser profiling (percentage of sampled traces)
-		profilesSampleRate: .1,
+		profilesSampleRate: 0.1,
 
 		// Capture Replay for 10% of all sessions,
 		// plus for 100% of sessions with an error

--- a/app/utils/monitoring.client.tsx
+++ b/app/utils/monitoring.client.tsx
@@ -11,6 +11,7 @@ export function init() {
 	sentryInit({
 		dsn: ENV.SENTRY_DSN,
 		environment: ENV.MODE,
+		release: ENV.COMMIT_SHA,
 		beforeSend(event) {
 			try {
 				const maybeUrl = event.request?.url
@@ -43,7 +44,10 @@ export function init() {
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
-		tracesSampleRate: 1.0,
+		tracesSampleRate: .1,
+
+		// Enable browser profiling (percentage of sampled traces)
+		profilesSampleRate: .1,
 
 		// Capture Replay for 10% of all sessions,
 		// plus for 100% of sessions with an error

--- a/app/utils/preview-utils.server.ts
+++ b/app/utils/preview-utils.server.ts
@@ -4,51 +4,51 @@ import { cache } from '#app/utils/cache.server.ts'
 const MDX_CACHE_PREFIX_V2 = 'mdx:bundle:'
 
 export function mdxCacheKeyFor(source: string, title?: string) {
-  const hash = crypto.createHash('sha1').update(source).digest('hex')
-  const titlePart = title?.trim() ? title.trim() : 'untitled'
-  return `${MDX_CACHE_PREFIX_V2}${titlePart}:${hash}`
+	const hash = crypto.createHash('sha1').update(source).digest('hex')
+	const titlePart = title?.trim() ? title.trim() : 'untitled'
+	return `${MDX_CACHE_PREFIX_V2}${titlePart}:${hash}`
 }
 
 export function extractPreviewUrls(markdown: string): string[] {
-  const urls = new Set<string>()
-  if (!markdown) return []
+	const urls = new Set<string>()
+	if (!markdown) return []
 
-  // Matches :preview{url=...} or :preview{#=...}
-  const re = /:preview\{([^}]*)\}/gim
-  let m: RegExpExecArray | null
-  while ((m = re.exec(markdown))) {
-    const inside = m[1] ?? ''
-    // Try url=...
-    const urlMatch = inside.match(/\burl\s*=\s*([^\s}]+)/i)
-    // Or shorthand #=...
-    const hashMatch = inside.match(/#\s*=\s*([^\s}]+)/)
-    const raw = (urlMatch?.[1] || hashMatch?.[1] || '').trim()
-    if (!raw) continue
-    const cleaned = raw.replace(/^['"]|['"]$/g, '')
-    urls.add(cleaned)
-  }
+	// Matches :preview{url=...} or :preview{#=...}
+	const re = /:preview\{([^}]*)\}/gim
+	let m: RegExpExecArray | null
+	while ((m = re.exec(markdown))) {
+		const inside = m[1] ?? ''
+		// Try url=...
+		const urlMatch = inside.match(/\burl\s*=\s*([^\s}]+)/i)
+		// Or shorthand #=...
+		const hashMatch = inside.match(/#\s*=\s*([^\s}]+)/)
+		const raw = (urlMatch?.[1] || hashMatch?.[1] || '').trim()
+		if (!raw) continue
+		const cleaned = raw.replace(/^['"]|['"]$/g, '')
+		urls.add(cleaned)
+	}
 
-  return Array.from(urls)
+	return Array.from(urls)
 }
 
 export async function invalidatePostCaches(
-  oldContent?: string,
-  newContent?: string,
-  oldTitle?: string,
-  newTitle?: string,
+	oldContent?: string,
+	newContent?: string,
+	oldTitle?: string,
+	newTitle?: string,
 ) {
-  const urls = new Set<string>([
-    ...(oldContent ? extractPreviewUrls(oldContent) : []),
-    ...(newContent ? extractPreviewUrls(newContent) : []),
-  ])
+	const urls = new Set<string>([
+		...(oldContent ? extractPreviewUrls(oldContent) : []),
+		...(newContent ? extractPreviewUrls(newContent) : []),
+	])
 
-  // Invalidate link preview cache entries
-  await Promise.all(
-    Array.from(urls).map((u) => cache.delete?.(`link-preview:${u}`)),
-  )
+	// Invalidate link preview cache entries
+	await Promise.all(
+		Array.from(urls).map((u) => cache.delete?.(`link-preview:${u}`)),
+	)
 
-  // Invalidate prior compiled MDX if available
-  if (oldContent) {
-    await cache.delete?.(mdxCacheKeyFor(oldContent, oldTitle))
-  }
+	// Invalidate prior compiled MDX if available
+	if (oldContent) {
+		await cache.delete?.(mdxCacheKeyFor(oldContent, oldTitle))
+	}
 }

--- a/app/utils/s3.server.ts
+++ b/app/utils/s3.server.ts
@@ -17,13 +17,13 @@ export const s3 = new S3Client({
 })
 
 export async function getSignedUploadUrl(key: string, contentType: string) {
-    const command = new PutObjectCommand({
-        Bucket: process.env.AWS_BUCKET_NAME,
-        Key: key,
-        ContentType: contentType,
-        CacheControl: IMMUTABLE_CACHE_CONTROL,
-    })
-    return getSignedUrl(s3, command, { expiresIn: 3600 })
+	const command = new PutObjectCommand({
+		Bucket: process.env.AWS_BUCKET_NAME,
+		Key: key,
+		ContentType: contentType,
+		CacheControl: IMMUTABLE_CACHE_CONTROL,
+	})
+	return getSignedUrl(s3, command, { expiresIn: 3600 })
 }
 
 export async function getSignedGetUrl(key: string) {

--- a/index.js
+++ b/index.js
@@ -17,32 +17,32 @@ sourceMapSupport.install({
 
 // Load .env early in non-production environments. On Fly, use real env vars.
 if (process.env.NODE_ENV !== 'production') {
-    try {
-        await import('dotenv/config')
-    } catch {
-        // ignore if dotenv is not installed
-    }
+	try {
+		await import('dotenv/config')
+	} catch {
+		// ignore if dotenv is not installed
+	}
 }
 
 // In production, ensure INTERNAL_COMMAND_TOKEN is available. Dockerfile writes it to /myapp/.env.
 if (
-    process.env.NODE_ENV === 'production' &&
-    !process.env.INTERNAL_COMMAND_TOKEN
+	process.env.NODE_ENV === 'production' &&
+	!process.env.INTERNAL_COMMAND_TOKEN
 ) {
-    try {
-        const envPath = new URL('./.env', import.meta.url)
-        const raw = fs.readFileSync(envPath, 'utf8')
-        for (const line of raw.split('\n')) {
-            const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
-            if (!m) continue
-            const key = m[1]
-            let val = m[2]
-            val = val.replace(/^['"]|['"]$/g, '')
-            if (!(key in process.env)) process.env[key] = val
-        }
-    } catch {
-        // ignore if file missing
-    }
+	try {
+		const envPath = new URL('./.env', import.meta.url)
+		const raw = fs.readFileSync(envPath, 'utf8')
+		for (const line of raw.split('\n')) {
+			const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
+			if (!m) continue
+			const key = m[1]
+			let val = m[2]
+			val = val.replace(/^['"]|['"]$/g, '')
+			if (!(key in process.env)) process.env[key] = val
+		}
+	} catch {
+		// ignore if file missing
+	}
 }
 
 if (process.env.MOCKS === 'true') {

--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -31,13 +31,13 @@ RUN npm prune --omit=dev
 # Build the app
 FROM base as build
 
+# Build args for build-time Sentry uploads 
 ARG COMMIT_SHA
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
 ENV COMMIT_SHA=$COMMIT_SHA
-
-# Use the following environment variables to configure Sentry
-# ENV SENTRY_ORG=
-# ENV SENTRY_PROJECT=
-
+ENV SENTRY_ORG=$SENTRY_ORG
+ENV SENTRY_PROJECT=$SENTRY_PROJECT
 
 WORKDIR /myapp
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -21,15 +21,15 @@ async function uploadToS3(filepath: string, contentType: string) {
 	const key = `seed/${Date.now()}-${filename}`
 	const fileBuffer = await fs.readFile(filepath)
 
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: process.env.AWS_BUCKET_NAME,
-      Key: key,
-      Body: fileBuffer,
-      ContentType: contentType,
-      CacheControl: 'public, max-age=31536000, immutable',
-    }),
-  )
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: process.env.AWS_BUCKET_NAME,
+			Key: key,
+			Body: fileBuffer,
+			ContentType: contentType,
+			CacheControl: 'public, max-age=31536000, immutable',
+		}),
+	)
 
 	return key
 }

--- a/scripts/backfill-post-image-dimensions.ts
+++ b/scripts/backfill-post-image-dimensions.ts
@@ -2,81 +2,85 @@
 // Load local .env only during development so production
 // environments (like Fly) don't require the dotenv package.
 if (process.env.NODE_ENV !== 'production') {
-  await import('dotenv/config')
+	await import('dotenv/config')
 }
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import sharp from 'sharp'
 import { prisma } from '../app/utils/db.server.ts'
 
 async function streamToBuffer(stream: any): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
-    const chunks: Buffer[] = []
-    stream.on('data', (chunk: Buffer) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
-    stream.on('end', () => resolve(Buffer.concat(chunks)))
-    stream.on('error', reject)
-  })
+	return new Promise<Buffer>((resolve, reject) => {
+		const chunks: Buffer[] = []
+		stream.on('data', (chunk: Buffer) =>
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+		)
+		stream.on('end', () => resolve(Buffer.concat(chunks)))
+		stream.on('error', reject)
+	})
 }
 
 async function main() {
-  const required = [
-    'AWS_REGION',
-    'AWS_ACCESS_KEY_ID',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_BUCKET_NAME',
-    // Database URL is required by Prisma under the hood
-    'DATABASE_URL',
-  ] as const
+	const required = [
+		'AWS_REGION',
+		'AWS_ACCESS_KEY_ID',
+		'AWS_SECRET_ACCESS_KEY',
+		'AWS_BUCKET_NAME',
+		// Database URL is required by Prisma under the hood
+		'DATABASE_URL',
+	] as const
 
-  const missing = required.filter((k) => !process.env[k])
-  if (missing.length) {
-    console.error(
-      `Missing required env vars: ${missing.join(', ')}. Did you configure .env?`,
-    )
-    process.exit(1)
-  }
+	const missing = required.filter((k) => !process.env[k])
+	if (missing.length) {
+		console.error(
+			`Missing required env vars: ${missing.join(', ')}. Did you configure .env?`,
+		)
+		process.exit(1)
+	}
 
-  const s3 = new S3Client({
-    region: process.env.AWS_REGION,
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-    },
-  })
+	const s3 = new S3Client({
+		region: process.env.AWS_REGION,
+		credentials: {
+			accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+			secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+		},
+	})
 
-  const images = await prisma.postImage.findMany({
-    where: { OR: [{ width: null }, { height: null }] },
-    select: { id: true, s3Key: true },
-  })
-  console.log(`Found ${images.length} images missing dimensions`)
+	const images = await prisma.postImage.findMany({
+		where: { OR: [{ width: null }, { height: null }] },
+		select: { id: true, s3Key: true },
+	})
+	console.log(`Found ${images.length} images missing dimensions`)
 
-  for (const img of images) {
-    try {
-      const res = await s3.send(new GetObjectCommand({
-        Bucket: process.env.AWS_BUCKET_NAME,
-        Key: img.s3Key,
-      }))
-      const body = res.Body as any
-      if (!body) {
-        console.warn(`No body for ${img.id}`)
-        continue
-      }
-      const buf = await streamToBuffer(body)
-      const meta = await sharp(buf).metadata()
-      await prisma.postImage.update({
-        where: { id: img.id },
-        data: { width: meta.width ?? null, height: meta.height ?? null },
-      })
-      console.log(`Updated ${img.id} -> ${meta.width}x${meta.height}`)
-    } catch (e) {
-      console.error(`Failed ${img.id}`, e)
-    }
-  }
+	for (const img of images) {
+		try {
+			const res = await s3.send(
+				new GetObjectCommand({
+					Bucket: process.env.AWS_BUCKET_NAME,
+					Key: img.s3Key,
+				}),
+			)
+			const body = res.Body as any
+			if (!body) {
+				console.warn(`No body for ${img.id}`)
+				continue
+			}
+			const buf = await streamToBuffer(body)
+			const meta = await sharp(buf).metadata()
+			await prisma.postImage.update({
+				where: { id: img.id },
+				data: { width: meta.width ?? null, height: meta.height ?? null },
+			})
+			console.log(`Updated ${img.id} -> ${meta.width}x${meta.height}`)
+		} catch (e) {
+			console.error(`Failed ${img.id}`, e)
+		}
+	}
 
-  console.log('Done')
-  await prisma.$disconnect()
+	console.log('Done')
+	await prisma.$disconnect()
 }
 
 main().catch((e) => {
-  console.error(e)
-  process.exit(1)
+	console.error(e)
+	process.exit(1)
 })

--- a/scripts/backfill-post-image-dimensions.ts
+++ b/scripts/backfill-post-image-dimensions.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env -S tsx
-import 'dotenv/config'
+// Load local .env only during development so production
+// environments (like Fly) don't require the dotenv package.
+if (process.env.NODE_ENV !== 'production') {
+  await import('dotenv/config')
+}
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import sharp from 'sharp'
 import { prisma } from '../app/utils/db.server.ts'

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,14 +18,14 @@ const IS_DEV = MODE === 'development'
 const ALLOW_INDEXING = process.env.ALLOW_INDEXING !== 'false'
 const SENTRY_ENABLED = IS_PROD && process.env.SENTRY_DSN
 const ASSET_ORIGIN = (() => {
-  const raw = process.env.ASSET_BASE_URL?.trim()
-  if (!raw) return null
-  try {
-    const url = new URL(raw.startsWith('http') ? raw : `https://${raw}`)
-    return `${url.protocol}//${url.host}`
-  } catch {
-    return null
-  }
+	const raw = process.env.ASSET_BASE_URL?.trim()
+	if (!raw) return null
+	try {
+		const url = new URL(raw.startsWith('http') ? raw : `https://${raw}`)
+		return `${url.protocol}//${url.host}`
+	} catch {
+		return null
+	}
 })()
 
 if (SENTRY_ENABLED) {
@@ -119,7 +119,7 @@ app.use(
 		xPoweredBy: false,
 		referrerPolicy: { policy: 'same-origin' },
 		crossOriginEmbedderPolicy: false,
-    contentSecurityPolicy: {
+		contentSecurityPolicy: {
 			// NOTE: Remove reportOnly when you're ready to enforce this CSP
 			reportOnly: true,
 			directives: {
@@ -130,12 +130,14 @@ app.use(
 				].filter(Boolean),
 				'font-src': ["'self'"],
 				'frame-src': ["'self'", 'https://www.youtube.com/'],
-        'img-src': ["'self'", 'data:', ASSET_ORIGIN].filter(Boolean) as string[],
-        'media-src': [
-          "'self'",
-          'https://jdg-media.s3.us-east-2.amazonaws.com',
-          ASSET_ORIGIN,
-        ].filter(Boolean) as string[],
+				'img-src': ["'self'", 'data:', ASSET_ORIGIN].filter(
+					Boolean,
+				) as string[],
+				'media-src': [
+					"'self'",
+					'https://jdg-media.s3.us-east-2.amazonaws.com',
+					ASSET_ORIGIN,
+				].filter(Boolean) as string[],
 				'script-src': [
 					"'strict-dynamic'",
 					"'self'",
@@ -324,29 +326,31 @@ async function prewarmPublishedFragments() {
 
 // Wait for readiness, then kick off prewarm in background
 async function waitForReadiness(origin: string, timeoutMs = 60000) {
-    const start = Date.now()
-    const url = `${origin}/resources/readiness`
-    let attempt = 0
-    while (Date.now() - start < timeoutMs) {
-        attempt++
-        try {
-            const res = await fetch(url, { headers: { 'X-Healthcheck': 'true' } })
-            if (res.ok) return true
-        } catch {
-            // ignore
-        }
-        await new Promise((r) => setTimeout(r, Math.min(500 + attempt * 250, 3000)))
-    }
-    return false
+	const start = Date.now()
+	const url = `${origin}/resources/readiness`
+	let attempt = 0
+	while (Date.now() - start < timeoutMs) {
+		attempt++
+		try {
+			const res = await fetch(url, { headers: { 'X-Healthcheck': 'true' } })
+			if (res.ok) return true
+		} catch {
+			// ignore
+		}
+		await new Promise((r) => setTimeout(r, Math.min(500 + attempt * 250, 3000)))
+	}
+	return false
 }
 
 void (async () => {
-    const origin = `http://127.0.0.1:${portToUse}`
-    const ready = await waitForReadiness(origin)
-    if (!ready) {
-        console.info('🧯 Prewarm: readiness not confirmed after timeout; proceeding anyway')
-    }
-    void prewarmPublishedFragments()
+	const origin = `http://127.0.0.1:${portToUse}`
+	const ready = await waitForReadiness(origin)
+	if (!ready) {
+		console.info(
+			'🧯 Prewarm: readiness not confirmed after timeout; proceeding anyway',
+		)
+	}
+	void prewarmPublishedFragments()
 })()
 
 closeWithGrace(async ({ err }) => {

--- a/server/utils/monitoring.ts
+++ b/server/utils/monitoring.ts
@@ -5,6 +5,7 @@ export function init() {
 	Sentry.init({
 		dsn: process.env.SENTRY_DSN,
 		environment: process.env.NODE_ENV,
+		release: process.env.COMMIT_SHA,
 		tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0,
 		autoInstrumentRemix: true,
 		denyUrls: [
@@ -22,6 +23,8 @@ export function init() {
 			Sentry.prismaIntegration(),
 			nodeProfilingIntegration(),
 		],
+		// Enable Node.js profiling (percentage of sampled traces)
+		profilesSampleRate: .1,
 		tracesSampler(samplingContext) {
 			// ignore healthcheck transactions by other services (consul, etc.)
 			if (samplingContext.request?.url?.includes('/resources/healthcheck')) {

--- a/server/utils/monitoring.ts
+++ b/server/utils/monitoring.ts
@@ -24,7 +24,7 @@ export function init() {
 			nodeProfilingIntegration(),
 		],
 		// Enable Node.js profiling (percentage of sampled traces)
-		profilesSampleRate: .1,
+		profilesSampleRate: 0.1,
 		tracesSampler(samplingContext) {
 			// ignore healthcheck transactions by other services (consul, etc.)
 			if (samplingContext.request?.url?.includes('/resources/healthcheck')) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,9 @@ export default defineConfig({
 			}
 		},
 
-		sourcemap: MODE === 'development',
+		// Generate sourcemaps for development; use hidden maps in production
+		// so the sourceMappingURL comment is omitted from built files.
+		sourcemap: MODE === 'production' ? 'hidden' : MODE === 'test' ? false : true,
 	},
 	server: {
 		watch: {
@@ -57,8 +59,7 @@ export default defineConfig({
 					},
 					sourcemaps: {
 						filesToDeleteAfterUpload: await glob([
-							'./build/**/*.map',
-							'.server-build/**/*.map',
+							'./build/client/**/*.map',
 						]),
 					},
 				})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,8 @@ export default defineConfig({
 
 		// Generate sourcemaps for development; use hidden maps in production
 		// so the sourceMappingURL comment is omitted from built files.
-		sourcemap: MODE === 'production' ? 'hidden' : MODE === 'test' ? false : true,
+		sourcemap:
+			MODE === 'production' ? 'hidden' : MODE === 'test' ? false : true,
 	},
 	server: {
 		watch: {
@@ -58,9 +59,7 @@ export default defineConfig({
 						},
 					},
 					sourcemaps: {
-						filesToDeleteAfterUpload: await glob([
-							'./build/client/**/*.map',
-						]),
+						filesToDeleteAfterUpload: await glob(['./build/client/**/*.map']),
 					},
 				})
 			: null,


### PR DESCRIPTION
- fix(monitoring): guard invalid URLs in Sentry beforeSend; fix healthcheck protocol
- feat(images): stream from S3 with caching and range support
- feat(videos): stream from S3 with caching and range support
- feat(env,media): add ASSET_BASE_URL and client-side CDN prefixing
- fix(link-preview): add read timeout, URL scheme guard, and server-side cache
- feat(mdx): cachify bundleMDX by content hash (SQLite+LRU)
- feat(prewarm): add prewarm route and server trigger to warm MDX cache on boot
- fix(fragments): correct pagination disable logic and clamping
- fix(prewarm): satisfy TS by snapshotting index per loop iteration
- chore(deps): bump react-router packages
- chore(stability): shallow healthcheck + readiness, delay prewarm, client-side link preview JSON, increase Fly healthcheck timeout; fix no-floating-promises
- fix(performance): link preview with semaphore
- chore: format
- Revert "fix(performance): link preview with semaphore"
- chore: rename func
- fix: link previews
- fix: format
- fix: actually fetch previews on prewarm
- feat(components): add static link preview for mdx
- fix: link preview not rendering in mdx editor
- chore: delete unused localStorare preview cache
- feat: update mdx editor for link preview
- feat(fragments,previews): update caching invalidation logic
- feat: include dimensions with image
- feat: misc image updates add cloudfront, add image dims and loading state
- fix: env in backfill script
- fix: scroll resetting on fragments routes
- feat: miscellaneous mdx editor improvements toolbar styling preview render of directives
- feat(monitoring): update sentry to include releases and sourcemaps
